### PR TITLE
fix MongoClient issue in passport config

### DIFF
--- a/server/passport/passport-config.js
+++ b/server/passport/passport-config.js
@@ -10,7 +10,7 @@ const { User }    = require('../database/schemas');
 module.exports = app => {
   const sessionConfig = {
     store: MongoStore.create({
-      client: mongoose.connection.getClient(),
+      mongoUrl: process.env.DATABASE_URL,
       collectionName: 'sessions',
     }),
     genid: () => uuid.v4(),


### PR DESCRIPTION
Currently, in production, the passport-config fails to load and then throws an exception whenever a new session is created.
The result of the bug is that after the first login the system seems to work, but when we refresh we get an exception on the server-side and a blank page in the UI.

Logs from my Heroku for example:
```
2022-04-02T08:32:34.948076+00:00 app[web.1]: MongoNotConnectedError: MongoClient must be connected to perform this operation
2022-04-02T08:32:34.948084+00:00 app[web.1]: at getTopology (/app/node_modules/mongoose/node_modules/mongodb/lib/utils.js:369:11)
2022-04-02T08:32:34.948084+00:00 app[web.1]: at Collection.createIndex (/app/node_modules/mongoose/node_modules/mongodb/lib/collection.js:256:82)
2022-04-02T08:32:34.948085+00:00 app[web.1]: at MongoStore.setAutoRemove (/app/node_modules/connect-mongo/build/main/lib/MongoStore.js:147:35)
2022-04-02T08:32:34.948085+00:00 app[web.1]: at /app/node_modules/connect-mongo/build/main/lib/MongoStore.js:128:24
2022-04-02T08:32:34.948085+00:00 app[web.1]: at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

This pull request fixes the `MongoNotConnectedError: MongoClient must be connected to perform this operation`, by providing the database URL instead of the client.